### PR TITLE
Clarify README as snippet source and add links to canonical repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,31 @@
----
-name: Azure Functions binding examples in JavaScript
-description: Azure Functions examples using single and multi bindings. 
-languages:
-- javascript
-products:
-- azure
-- azure-sql-database
-- azure-cosmos-db
-- azure-storage
-- azure-functions
-page_type: sample
-urlFragment: functions-docs-javascript
----
+# Azure Functions JavaScript/TypeScript sample snippets repository
 
-# Azure Functions binding examples in JavaScript
+This repository contains JavaScript and TypeScript source code snippets used as `:::code` includes in [Azure Functions documentation](https://learn.microsoft.com/azure/azure-functions/). It is **not** intended as a standalone sample or project template.
 
-The following samples are used as a basis for [Azure Functions 2.x+ binding](https://docs.microsoft.com/azure/azure-functions/functions-triggers-bindings#supported-bindings) examples in JavaScript.
+## Contents
 
-## Settings and configuration
+| Folder | Purpose |
+|--------|---------|
+| `src/` | Basic HTTP trigger functions (v4 model) |
+| `functions-add-output-binding-storage-queue-cli-v4-programming-model/` | HTTP trigger + Storage Queue output (JavaScript, v4) |
+| `functions-add-output-binding-storage-queue-cli-v4-programming-model-ts/` | HTTP trigger + Storage Queue output (TypeScript, v4) |
+| `functions-add-output-binding-cosmosdb-cli-v4-programming-model/` | HTTP trigger + Cosmos DB output (JavaScript, v4) |
+| `functions-add-output-binding-sql-cli-v4-programming-model/` | HTTP trigger + SQL output (JavaScript, v4) |
+| `functions-typescript/` | TypeScript examples (v3 model, legacy) |
+| `functions-add-output-binding-storage-queue-cli/` | Storage Queue output (v3 model, legacy) |
 
-The *local.settings.example.json* file is provided for your convenience. Rename the file to *local.settings.json* and add your own connection and API values before trying to run the examples in this repo.
+## Canonical scenario repositories
 
-If you're using Visual Studio Code, you can use the [REST Client](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) extension with the *routes.http* file. This file gives you the ability to call sample functions with a single click inside VS Code.
+If you're looking for complete, deployable Azure Functions projects in JavaScript or TypeScript, use these `azd`-compatible templates instead:
 
-## Samples
+**JavaScript:**
+- [functions-quickstart-javascript-azd](https://github.com/Azure-Samples/functions-quickstart-javascript-azd) — HTTP trigger
+- [functions-quickstart-javascript-azd-timer](https://github.com/Azure-Samples/functions-quickstart-javascript-azd-timer) — Timer trigger
+- [functions-quickstart-javascript-azd-cosmosdb](https://github.com/Azure-Samples/functions-quickstart-javascript-azd-cosmosdb) — Azure Cosmos DB trigger
+- [functions-quickstart-javascript-azd-eventhub](https://github.com/Azure-Samples/functions-quickstart-javascript-azd-eventhub) — Event Hubs trigger
 
-The following samples are available in this repo.
-
-| Name | Description  | Trigger | Input | Output |
-|------|--------------|---------|-------|--------|
-| [HttpTrigger](HttpTrigger) | Triggered by an HTTP request. | Http | N/A | Http |
-| [HttpTriggerRoute](HttpTriggerRoute) | Triggered by an HTTP request, writes a queue message. | Http | N/A | Queue |
-| [HttpAndTable](HttpAndTable) | Triggered by an HTTP request, writes a queue message. | Http | Table | Http |
-| [QueueTrigger](QueueTrigger) | Reads a queue message | Queue | Queue | N/A |
-
-## Samples with extra outputs
-
-Extra outputs are a way to process incoming HTTP information into more an Azure service without having to write code to use the Azure client library for that SDK. 
-
-The following samples are available in this repo.
-
-| Name | Description  | Trigger | Input | Output |
-|------|--------------|---------|-------|--------|
-| [Azure Sql](functions-add-output-binding-sql-cli-v4-programming-model)| Triggered by an HTTP request, writes to Azure Sql Table. [Documentation](/azure/azure-functions/functions-add-output-binding-azure-sql-vs-code?pivots=programming-language-javascript)| Http | Http | Azure Sql + HTTP |
-| [Cosmos DB](functions-add-output-binding-cosmosdb-cli-v4-programming-model) | Triggered by an HTTP request, writes a Cosmos DB container. [Documentation](/azure/azure-functions/functions-add-output-binding-azure-sql-vs-code?pivots=programming-language-javascript)| Http | Http | Cosmos DB + HTTP |
-| [Storage Queue](functions-add-output-binding-storage-queue-cli-v4-programming-model) | Triggered by an HTTP request, writes a Storage queue message. [Documentation](/azure/azure-functions/functions-add-output-binding-storage-queue-vs-code?pivots=programming-language-javascript&tabs=isolated-process) | Http | HTTP | Storage Queue + HTTP |
+**TypeScript:**
+- [functions-quickstart-typescript-azd](https://github.com/Azure-Samples/functions-quickstart-typescript-azd) — HTTP trigger
+- [functions-quickstart-typescript-azd-timer](https://github.com/Azure-Samples/functions-quickstart-typescript-azd-timer) — Timer trigger
+- [functions-quickstart-typescript-azd-cosmosdb](https://github.com/Azure-Samples/functions-quickstart-typescript-azd-cosmosdb) — Azure Cosmos DB trigger
+- [functions-quickstart-typescript-azd-eventhub](https://github.com/Azure-Samples/functions-quickstart-typescript-azd-eventhub) — Event Hubs trigger


### PR DESCRIPTION
- Clarify that this repo is a `:::code` snippet source for Azure Functions docs (not a standalone template)
- Document folder contents and their purposes
- Add links to canonical azd-compatible JavaScript and TypeScript quickstart repos
- Remove YAML frontmatter (not needed for snippet repos)